### PR TITLE
Namespaceendring og dokumentasjon.

### DIFF
--- a/avro-skjema/pom.xml
+++ b/avro-skjema/pom.xml
@@ -26,6 +26,26 @@
         <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
         <plugins>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.5</version>
+                <executions>
+                    <execution>
+                        <id>auto-clean</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.basedir}/src/main/java</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
                 <version>1.10.0</version>

--- a/avro-skjema/src/main/avro/beskjed.avsc
+++ b/avro-skjema/src/main/avro/beskjed.avsc
@@ -1,30 +1,35 @@
 {
   "type": "record",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "name": "Beskjed",
   "fields": [
     {
       "name": "tidspunkt",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Tidspunkt for når hendelsen skjedde"
     },
     {
       "name": "synligFremTil",
       "type": ["null", "long"],
       "logicalType": "timestamp-millis",
-      "default": null
+      "default": null,
+      "doc": "For hvor lenge beskjeden skal vises. Er den null, så er det ingen begrensning"
     },
     {
       "name": "mottaker",
-      "type": "Mottaker"
+      "type": "Mottaker",
+      "doc": "Hvem som skal se beskjeden"
     },
     {
       "name": "grupperingsId",
-      "type": "string"
+      "type": "string",
+      "doc": "Id gitt av produsent av meldingen, som viser tilhørighet mellom notifikasjoner. F.eks. at de omhandler samme søknad."
     },
     {
       "name": "tekst",
-      "type": "string"
+      "type": "string",
+      "doc": "Teksten som presenteres til brukeren."
     },
     {
       "name": "link",

--- a/avro-skjema/src/main/avro/done.avsc
+++ b/avro-skjema/src/main/avro/done.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "name": "Done",
   "fields": [
     {

--- a/avro-skjema/src/main/avro/mottaker.avsc
+++ b/avro-skjema/src/main/avro/mottaker.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "name": "Mottaker",
   "fields": [
     {
@@ -8,8 +8,9 @@
       "type": [
         {
           "type": "record",
-          "namespace": "no.nav.arbeidsgiver",
+          "namespace": "no.nav.arbeidsgiver.notifikasjon",
           "name": "OrgnrFnr",
+          "doc": "Mottas av dem med gitt fnr i konteksten av et bestemt orgnr",
           "fields": [
             {
               "name": "orgnr",
@@ -23,8 +24,9 @@
         },
         {
           "type": "record",
-          "namespace": "no.nav.arbeidsgiver",
+          "namespace": "no.nav.arbeidsgiver.notifikasjon",
           "name": "OrgnrAltinnservice",
+          "doc": "Mottas av alle som har tilgang til altinn-tjenesten i det gitte orgnr",
           "fields": [
             {
               "name": "orgnr",

--- a/avro-skjema/src/main/avro/nokkelV1.avsc
+++ b/avro-skjema/src/main/avro/nokkelV1.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "name": "Nokkel",
   "fields": [
     {

--- a/avro-skjema/src/main/avro/notifikasjonV1.avsc
+++ b/avro-skjema/src/main/avro/notifikasjonV1.avsc
@@ -1,6 +1,6 @@
 {"type": "record",
   "name": "Notifikasjon",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "fields": [
     {"name": "id", "type": "string"},
     {"name": "beskjed", "type": "string"},

--- a/avro-skjema/src/main/avro/oppgave.avsc
+++ b/avro-skjema/src/main/avro/oppgave.avsc
@@ -1,7 +1,7 @@
 
 {
   "type": "record",
-  "namespace": "no.nav.arbeidsgiver",
+  "namespace": "no.nav.arbeidsgiver.notifikasjon",
   "name": "Oppgave",
   "fields": [
     {


### PR DESCRIPTION
Slett generert kode før maven bygger avro-skjema, siden avro-pluginen ikke
overskriver eksisterende filer.

Endret namespace til no.nav.arbeidsgiver.notifikasjon, så vi ikke forurenser for hele PO arbeidsgiver.